### PR TITLE
Fix wait() call under Linux

### DIFF
--- a/src/Bootil/Platform/Platform_LINUX.cpp
+++ b/src/Bootil/Platform/Platform_LINUX.cpp
@@ -17,6 +17,7 @@
 #include <sys/types.h>
 #include <sys/time.h>
 #include <sys/select.h>
+#include <sys/wait.h>
 
 #ifdef X11_GRAPHICAL
 #include <X11/Xlib.h>
@@ -221,7 +222,7 @@ namespace Bootil
 				bool isOk = ( pid > 0 );
 
 				if ( isOk && AndWait )
-				{ wait(); }
+				{ waitpid(pid, NULL, 0); }
 			}
 			else
 			{


### PR DESCRIPTION
There's no documentation of a wait() call that takes no arguments in any
POSIX standards documentations - everywhere says it should take a status
pointer. This uses waitpid instead, which waits for a specific PID
(which fixes an issue where multiple calls to StartProcess could end up
waiting for the wrong process to end).